### PR TITLE
Update call to yaml.load to specify Loader

### DIFF
--- a/ninja_utils/config/settings.py
+++ b/ninja_utils/config/settings.py
@@ -14,7 +14,7 @@ class Settings:
 
         if os.path.exists(os.path.join(config_dir, 'SETTINGS.yaml')):
             with open(os.path.join(config_dir, 'SETTINGS.yaml')) as inf_handle:
-                yaml_dict = yaml.load(inf_handle)
+                yaml_dict = yaml.load(inf_handle, Loader=yaml.FullLoader)
                 if yaml_dict and submodule in yaml_dict:
                     sm_dict = yaml_dict[submodule]
 


### PR DESCRIPTION
Calling `yaml.load` without specifying the `Loader` keyword is deprecated due to a CVE as of version 5; in 6, it fails completely (see: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation#how-to-disable-the-warning). PR specifies the suggested `FullLoader` in the `yaml.load` call.

Cheers,
Camille